### PR TITLE
Twitter カード と OGP用のメタタグを追加

### DIFF
--- a/_layout/head.html
+++ b/_layout/head.html
@@ -14,6 +14,23 @@
   <link rel="mask-icon" href="safari-pinned-tab.svg" color="#5bbad5">
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@JuliaLangJA">
+  <meta name="twitter:title" content="JuliaLangJA">
+  <meta name="twitter:description" content="JuliaLangJa はプログラマー同士の交流を目的とした Julia 言語に関する日本語コミュニティです。">
+  <meta name="twitter:image" content="https://julialangja.github.io/assets/julialangja-biglogo.png">
+  
+  <!-- Open Graph -->
+  <meta property="og:title" content="JuliaLangJA">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://julialangja.github.io/">
+  <meta property="og:image" content="https://julialangja.github.io/assets/julialangja-biglogo.png">
+  <meta property="og:description" content="JuliaLangJa はプログラマー同士の交流を目的とした Julia 言語に関する日本語コミュニティです。">
+  <meta property="og:site_name" content="JuliaLangJA">
+  <meta property="og:locale" content="ja_JP">
+  
   {{isdef title}} <title>{{fill title}}</title>  {{end}}
 </head>
 <body>


### PR DESCRIPTION
ツイートしたときやリンクを展開したときにいい感じのタグが出るように各種タグを追加しました。