### PR TITLE
Add labs.md #3

### DIFF
--- a/labs.md
+++ b/labs.md
@@ -1,0 +1,38 @@
+@def title = "日本で Julia を利用している研究室一覧"
+@def hasmath = false
+
+# 日本で Julia を利用している研究室一覧
+
+日本国内でJuliaを活用している研究室をまとめます。追加したい研究室がある場合は[こちらのファイル](https://github.com/JuliaLangJa/julialangja.github.io/blob/main/labs.md)に追記してプルリクエストを送ってください。50音順にソートしてください。コミットログは英語でも日本語でも大丈夫です。ご意見・ご提案は [Issues](https://github.com/JuliaLangJa/julialangja.github.io/issues) へお気軽にご連絡ください。
+
+## テンプレート
+
+```
+### [機関名 研究室名](研究室URL)
+
+- 箇条書きで Julia の活用事例など
+- 箇条書きで Julia の活用事例など
+- 箇条書きで Julia の活用事例など
+
+研究室の説明やアピールを好きなだけ
+```
+
+## 研究室一覧
+
+### [理化学研究所 少数多体系物理研究室](https://www.riken.jp/research/labs/rnc/few-body_syst_phys/index.html)
+
+- [Mass Ratio Dependence of Three-Body Resonance Lifetimes in 1D and 3D](https://arxiv.org/abs/2312.04080)
+- [Structure of Heavy Mesons in the Light-Front Quark Model](https://arxiv.org/abs/2401.07933)
+- [TwoBody.jl](https://github.com/ohno/TwoBody.jl)
+- [FewBodyToolkit.jl](https://github.com/lhapp27/FewBodyToolkit.jl)
+- [FewBodyToolkit.jl: a Julia package for solving quantum few-body problems](https://arxiv.org/abs/2510.04447)
+
+ハドロンから原子分子までの少数多体系物理学の研究に活用しながら、いくつかのパッケージを開発・公開しています。
+
+## 謝辞
+
+このページは下記のページを参考に作成されました。
+
+- [日本で Erlang/OTP や Elixir を利用している会社一覧](https://github.com/voluntas/japanese-erlang-elixir-companies)
+- [日本で Clojure/ClojureScript を利用している会社一覧](https://github.com/athos/japanese-clojure-companies)
+- [日本で Rust を利用している会社一覧](https://github.com/fnwiya/japanese-rust-companies)

--- a/labs.md
+++ b/labs.md
@@ -3,7 +3,11 @@
 
 # 日本で Julia を利用している研究室一覧
 
-日本国内でJuliaを活用している研究室をまとめます。追加したい研究室がある場合は[こちらのファイル](https://github.com/JuliaLangJa/julialangja.github.io/blob/main/labs.md)に追記してプルリクエストを送ってください。50音順にソートしてください。コミットログは英語でも日本語でも大丈夫です。ご意見・ご提案は [Issues](https://github.com/JuliaLangJa/julialangja.github.io/issues) へお気軽にご連絡ください。
+日本国内でJuliaを活用している研究室をまとめます。
+追加したい研究室がある場合は[こちらのファイル](https://github.com/JuliaLangJa/julialangja.github.io/blob/main/labs.md)に追記してプルリクエストを送ってください。
+50音順にソートしてください。
+コミットログは英語でも日本語でも大丈夫です。
+ご意見・ご提案は [Issues](https://github.com/JuliaLangJa/julialangja.github.io/issues) へお気軽にご連絡ください。
 
 ## テンプレート
 


### PR DESCRIPTION
日本でJuliaを活用している研究室の一覧を追加しました。中の人に連絡してプルリクを出してもらうか、許可をもらってこちらで追記する運用がよいと思っています。よければindex.mdに案内を追記し、企業一覧やイベント一覧も追加したいです。